### PR TITLE
Update nightly_builds.yml

### DIFF
--- a/nightly_builds.yml
+++ b/nightly_builds.yml
@@ -16,7 +16,7 @@ stages:
           certificate: 'certificat-dev'
         - env:
           name: 'staging'
-          provisioningProfile: 'certificat-staging'
+          certificate: 'certificat-staging'
         - env:
           name: 'production'
-          provisioningProfile: 'certificat-production'
+          certificate: 'certificat-production'


### PR DESCRIPTION
changed parameter name 'provisioningProfile' to 'certificate' for staging and production environments